### PR TITLE
Set MetadataFactory on XmlSerializer

### DIFF
--- a/Resources/config/serializer.xml
+++ b/Resources/config/serializer.xml
@@ -62,7 +62,11 @@
         <service id="symfony.expression.language" class="%symfony.expression.language.class%" />
 
         <!-- Serializers & Handlers -->
-        <service id="hateoas.serializer.xml" class="%hateoas.serializer.xml.class%" public="false" />
+        <service id="hateoas.serializer.xml" class="%hateoas.serializer.xml.class%" public="false">
+            <call method="setMetadataFactory">
+                <argument type="service" id="jms_serializer.metadata_factory" />
+            </call>
+        </service>
         <service id="hateoas.serializer.json_hal" class="%hateoas.serializer.json_hal.class%" public="false" />
 
         <service id="hateoas.serializer.exclusion_manager" class="%hateoas.serializer.exclusion_manager.class%">


### PR DESCRIPTION
While using the XmlSerializer, I got a fatal error [there](https://github.com/willdurand/Hateoas/blob/master/src/Hateoas/Serializer/XmlSerializer.php#L89) so I added the call to `setMetadataFactory`.
