### PR TITLE
Allow overriding serializers

### DIFF
--- a/DependencyInjection/BazingaHateoasExtension.php
+++ b/DependencyInjection/BazingaHateoasExtension.php
@@ -14,6 +14,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Config\FileLocator;
 
 /**
@@ -51,5 +52,13 @@ class BazingaHateoasExtension extends Extension
                 new Alias($config['metadata']['cache'], false)
             );
         }
+
+        $container
+            ->getDefinition('hateoas.event_subscriber.json')
+            ->replaceArgument(0, new Reference($config['serializer']['json']));
+
+        $container
+            ->getDefinition('hateoas.event_subscriber.xml')
+            ->replaceArgument(0, new Reference($config['serializer']['xml']));
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -42,6 +42,13 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
             ->end()
+            ->arrayNode('serializer')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('json')->defaultValue('hateoas.serializer.json_hal')->end()
+                    ->scalarNode('xml')->defaultValue('hateoas.serializer.xml')->end()
+                ->end()
+            ->end()
         ;
 
         return $treeBuilder;

--- a/Resources/config/serializer.xml
+++ b/Resources/config/serializer.xml
@@ -72,14 +72,14 @@
         <!-- Subscribers -->
         <service id="hateoas.event_subscriber.xml" class="%hateoas.event_subscriber.xml.class%">
             <tag name="jms_serializer.event_subscriber" />
-            <argument type="service" id="hateoas.serializer.xml" />
+            <argument /> <!-- xml serializer -->
             <argument type="service" id="hateoas.links_factory" />
             <argument type="service" id="hateoas.embeds_factory" />
         </service>
 
         <service id="hateoas.event_subscriber.json" class="%hateoas.event_subscriber.json.class%">
             <tag name="jms_serializer.event_subscriber" />
-            <argument type="service" id="hateoas.serializer.json_hal" />
+            <argument /> <!-- json serializer -->
             <argument type="service" id="hateoas.links_factory" />
             <argument type="service" id="hateoas.embeds_factory" />
             <argument type="service" id="hateoas.inline_deferrer.embeds" />

--- a/Tests/Fixtures/JsonSerializer.php
+++ b/Tests/Fixtures/JsonSerializer.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Bazinga\Bundle\HateoasBundle\Tests\Fixtures;
+
+use Hateoas\Serializer\JsonSerializerInterface;
+use JMS\Serializer\JsonSerializationVisitor;
+use JMS\Serializer\SerializationContext;
+
+class JsonSerializer implements JsonSerializerInterface
+{
+    public function serializeLinks(array $links, JsonSerializationVisitor $visitor, SerializationContext $context)
+    {
+    }
+
+    public function serializeEmbeddeds(array $embeddeds, JsonSerializationVisitor $visitor, SerializationContext $context)
+    {
+    }
+}


### PR DESCRIPTION
Allow overriding serializers by setting service IDs in the bundle configuration.
