### PR TITLE
New expression language function: is_granted

### DIFF
--- a/ExpressionLanguage/ExpressionLanguage.php
+++ b/ExpressionLanguage/ExpressionLanguage.php
@@ -29,5 +29,14 @@ class ExpressionLanguage extends BaseExpressionLanguage
         }, function (array $variables, $value) {
             return $variables['container']->getParameter($value);
         });
+
+        $this->register('is_granted', function ($arg) {
+            return sprintf('call_user_func_array(array($this->get(security.context), isGranted), %s)', $arg);
+        }, function (array $variables, $value) {
+            return call_user_func_array(
+                array($variables['container']->get('security.context'), 'isGranted'),
+                $value
+            );
+        });
     }
 }

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -44,6 +44,61 @@ public function registerBundles()
 }
 ```
 
+Expression Language
+-------------------
+
+This bundle provides three extra functions to the expression language:
+
+## `is_granted`
+
+Allows you to exclude certain routes by checking whether the currently authenticated user
+has certain permissions or not. For example:
+
+```php
+/**
+ * @Hateoas\Relation(
+ *      "delete",
+ *      href = @Hateoas\Route(
+ *          "post_delete",
+ *          parameters = { "id" = "expr(object.getId())" }
+ *      ),
+ *      exclusion = @Hateoas\Exclusion(
+ *          excludeIf = "expr(not is_granted(['ROLE_ADMIN'])"
+ *      )
+ * )
+ */
+class Post
+{
+    // ...
+}
+```
+
+If the authenticated user has the `ROLE_ADMIN` role the route will be exposed, otherwise
+the route will be excluded.
+
+## `parameter`
+
+Allows you to fetch a parameter from the service container:
+
+```
+/**
+ * @Hateoas\Relation(
+ *      "delete",
+ *      href = @Hateoas\Route(
+ *          "post_delete",
+ *          parameters = { "foo" = "expr(parameter('foo'))" }
+ *      )
+ * )
+ */
+class Post
+{
+    // ...
+}
+```
+
+## `service`
+
+Allows you to fetch a service from the service container.
 
 Reference Configuration
 -----------------------


### PR DESCRIPTION
Using the `is_granted` expression language function allows users to check permissions for the active user while describing the HATEOAS serialization properties, i.e.:

``` php
/**
 * @Hateoas\Relation(
 *      "delete",
 *      href = @Hateoas\Route(
 *          "post_delete",
 *          parameters = { "id" = "expr(object.getId())" }
 *      ),
 *      exclusion = @Hateoas\Exclusion(
 *          excludeIf = "expr(not is_granted(['ROLE_ADMIN'])"
 *      )
 * )
 */
class Post
{
    // ...   
}
```

It is also possible to pass the object to the `is_granted` function:

``` php
/**
 * @Hateoas\Relation(
 *      "delete",
 *      href = @Hateoas\Route(
 *          "post_delete",
 *          parameters = { "id" = "expr(object.getId())" }
 *      ),
 *      exclusion = @Hateoas\Exclusion(
 *          excludeIf = "expr(not is_granted(['ROLE_ADMIN', object])"
 *      )
 * )
 */
class Post
{
    // ...   
}
```

This pull request fixes issue #29 
