### PR TITLE
Added relation provider compiler pass

### DIFF
--- a/DependencyInjection/Compiler/RelationProviderPass.php
+++ b/DependencyInjection/Compiler/RelationProviderPass.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This file is part of the HateoasBundle package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Bazinga\Bundle\HateoasBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+/**
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class RelationProviderPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $registryDefinition = $container->getDefinition('hateoas.configuration.provider.resolver.chain');
+
+        $relationProviderDefinitions = array();
+        foreach (array_keys($container->findTaggedServiceIds('hateoas.relation_provider')) as $id) {
+            $definition = $container->getDefinition($id);
+            $this->assertProvider($container, $definition);
+            $relationProviderDefinitions[] = $definition;
+        }
+
+        $registryDefinition->replaceArgument(0, $relationProviderDefinitions);
+    }
+
+    private function assertProvider(ContainerBuilder $container, Definition $definition)
+    {
+        $class = $container->getParameterBag()->resolveValue($definition->getClass());
+        $refClass = new \ReflectionClass($class);
+
+        if (!$refClass->implementsInterface('Hateoas\Configuration\Provider\Resolver\RelationProviderResolverInterface')) {
+            throw new InvalidArgumentException(sprintf(
+                'Relation provider "%s" does not implement the ReleationProviderResolver interface',
+                $definition->getClass()
+            ));
+        }
+    }
+}

--- a/Resources/config/configuration.xml
+++ b/Resources/config/configuration.xml
@@ -17,17 +17,20 @@
 
     <services>
         <service id="hateoas.configuration.provider.resolver.chain" class="%hateoas.configuration.provider.resolver.chain.class%" public="false">
-            <argument type="collection">
-                <argument type="service" id="hateoas.configuration.provider.resolver.method" />
-                <argument type="service" id="hateoas.configuration.provider.resolver.static_method" />
-                <argument type="service" id="hateoas.configuration.provider.resolver.symfony_container" />
-            </argument>
+            <argument type="collection"></argument>
         </service>
 
-        <service id="hateoas.configuration.provider.resolver.method" class="%hateoas.configuration.provider.resolver.method.class%" public="false"/>
-        <service id="hateoas.configuration.provider.resolver.static_method" class="%hateoas.configuration.provider.resolver.static_method.class%" public="false"/>
+        <service id="hateoas.configuration.provider.resolver.method" class="%hateoas.configuration.provider.resolver.method.class%" public="false">
+            <tag name="hateoas.relation_provider" />
+        </service>
+
+        <service id="hateoas.configuration.provider.resolver.static_method" class="%hateoas.configuration.provider.resolver.static_method.class%" public="false">
+            <tag name="hateoas.relation_provider" />
+        </service>
+
         <service id="hateoas.configuration.provider.resolver.symfony_container" class="%hateoas.configuration.provider.resolver.symfony_container.class%" public="false">
             <argument type="service" id="service_container"/>
+            <tag name="hateoas.relation_provider" />
         </service>
 
         <service id="hateoas.configuration.provider.resolver" alias="hateoas.configuration.provider.resolver.chain"/>

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -4,12 +4,6 @@ BazingaHateoasBundle
 This bundle integrates [Hateoas](http://github.com/willdurand/Hateoas) into
 [Symfony2](http://symfony.com).
 
-Usage
------
-
-Basically, this bundle does not need anything. You should look at the [Hateoas
-documentation](http://github.com/willdurand/Hateoas) for more information.
-
 Installation
 ------------
 
@@ -69,6 +63,34 @@ class AppKernel extends Kernel
  > }
  > ```
 
+Usage
+-----
+
+### Mapping Objects
+
+Refer to the [Hateoas documentation](http://github.com/willdurand/Hateoas) to
+find out how to map your objects.
+
+### Serializing objects
+
+The BazingaHateoasBundle transparently hooks into the JMS serializer, there
+are no special considerations:
+
+````php
+// My/Controller.php
+
+class SomeController extends Controller
+{
+    public function resourceAction(Request $request)
+    {
+        $post = $repository->find('BlogBundle:post');
+        $json = $this->container->get('serializer')->serialize($post, 'json');
+
+        return new Response($json, 200, 'application/json');
+    }
+}
+````
+
 Expression Language
 -------------------
 
@@ -124,6 +146,35 @@ class Post
 ## `service`
 
 Allows you to fetch a service from the service container.
+
+Extending
+---------
+
+### RelationProviderResolver
+
+A relation provider resolver is a class which provides a PHP callable. This
+callable will provide relations (links) for a given object.
+
+You can add new relation providers by implementing the 
+`Hateoas\Configuration\Provider\Resolver\RelationProviderResolverInterface`
+interface and adding a definition to the dependency injection configuration
+with the tag `hateoas.relation_provider`:
+
+````xml
+<?xml version="1.0" ?>
+<container ...>
+
+    <!-- ... -->
+
+    <services>
+        <!-- ... -->
+
+        <service id="acme_foo.hateoas.relation_provider_resolver.foobar" class="Acme\FooBundle\Hateoas\RelationProviderResolver\Foobar">
+            <tag name="hateoas.relation_provider" />
+        </service>
+    </services>
+</container>
+````
 
 Reference Configuration
 -----------------------

--- a/Tests/DependencyInjection/BazingaHateoasExtensionTest.php
+++ b/Tests/DependencyInjection/BazingaHateoasExtensionTest.php
@@ -13,6 +13,8 @@ use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPas
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Bazinga\Bundle\HateoasBundle\DependencyInjection\Compiler\RelationProviderPass;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
 class BazingaHateoasExtensionTest extends TestCase
 {
@@ -48,6 +50,29 @@ class BazingaHateoasExtensionTest extends TestCase
             )),
             $serializer->serialize(new SimpleObject('hello'), 'json')
         );
+    }
+
+    public function testRelationProviderPassInvalidProvider()
+    {
+        $container = $this->getContainerForConfig(array(array()));
+        $container->addCompilerPass(new RelationProviderPass());
+        $container->compile();
+        $definition = $container->getDefinition('hateoas.configuration.provider.resolver.chain');
+        $arguments = $definition->getArguments();
+        $this->assertCount(1, $arguments);
+        $this->assertCount(3, $arguments[0]);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testRelationProviderPass()
+    {
+        $container = $this->getContainerForConfig(array(array()));
+        $definition = $container->register('invalid_relation_provider', 'stdClass');
+        $definition->addTag('hateoas.relation_provider');
+        $container->addCompilerPass(new RelationProviderPass());
+        $container->compile();
     }
 
     public function testLoadUrlGenerator()


### PR DESCRIPTION
This PR adds a compiler pass which adds services tagged with `hateoas.relation_provider` to the chain provider.

Aims to fix #27