### PR TITLE
Drop PHP 5.4 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.4
     - 5.5
     - 5.6
     - 7.0

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     }
     ],
     "require": {
+        "php": ">5.4",
         "symfony/framework-bundle": "~2.2 || ~3.0",
         "willdurand/hateoas": "~2.9",
         "jms/serializer-bundle": "~1.0"


### PR DESCRIPTION
PHP 5.4 is unsupported since the 3rd of September 2015.

http://php.net/supported-versions.php