### PR TITLE
Ensure PHP 7 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ matrix:
     allow_failures:
         - env: SYMFONY_VERSION=dev-master
         - php: hhvm
-        - php: 7.0
 
 before_script:
     - composer self-update


### PR DESCRIPTION
PHP 7 compatibility should be ensured nowadays.