### PR TITLE
Allow jms serializer bundle 2.0 and removed some deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,6 @@ env:
     - SYMFONY_VERSION=3.0.* DEPS=low
     - SYMFONY_VERSION=3.2.* DEPS=low
 
-matrix:
-    allow_failures:
-        - php: hhvm
-
 before_script:
     - if [ "$DEPS" = 'low' ] ; then COMPOSER_PARAMS="--prefer-lowest --prefer-stable" ;  fi
     - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,11 @@ php:
     - hhvm
 
 env:
-    - SYMFONY_VERSION=2.2.*
     - SYMFONY_VERSION=2.3.*
     - SYMFONY_VERSION=2.4.*
     - SYMFONY_VERSION=2.8.*
     - SYMFONY_VERSION=3.0.*
     - SYMFONY_VERSION=3.2.*
-    - SYMFONY_VERSION=2.2.* DEPS=low
     - SYMFONY_VERSION=2.3.* DEPS=low
     - SYMFONY_VERSION=2.4.* DEPS=low
     - SYMFONY_VERSION=2.8.* DEPS=low

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,14 @@
 language: php
 
+sudo: false
+
+git:
+    depth: 1
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 php:
     - 5.5
     - 5.6
@@ -10,17 +19,25 @@ env:
     - SYMFONY_VERSION=2.2.*
     - SYMFONY_VERSION=2.3.*
     - SYMFONY_VERSION=2.4.*
-    - SYMFONY_VERSION=dev-master
+    - SYMFONY_VERSION=2.8.*
+    - SYMFONY_VERSION=3.0.*
+    - SYMFONY_VERSION=3.2.*
+    - SYMFONY_VERSION=2.2.* DEPS=low
+    - SYMFONY_VERSION=2.3.* DEPS=low
+    - SYMFONY_VERSION=2.4.* DEPS=low
+    - SYMFONY_VERSION=2.8.* DEPS=low
+    - SYMFONY_VERSION=3.0.* DEPS=low
+    - SYMFONY_VERSION=3.2.* DEPS=low
 
 matrix:
     allow_failures:
-        - env: SYMFONY_VERSION=dev-master
         - php: hhvm
 
 before_script:
+    - if [ "$DEPS" = 'low' ] ; then COMPOSER_PARAMS="--prefer-lowest --prefer-stable" ;  fi
     - composer self-update
     - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update
-    - composer update
+    - composer update $COMPOSER_PARAMS
 
 script:
     - ./vendor/bin/phpunit --coverage-text

--- a/Tests/DependencyInjection/BazingaHateoasExtensionTest.php
+++ b/Tests/DependencyInjection/BazingaHateoasExtensionTest.php
@@ -205,7 +205,6 @@ class BazingaHateoasExtensionTest extends TestCase
         $container->setParameter('kernel.bundles', array());
         $container->set('annotation_reader', new AnnotationReader());
         $container->set('router', $router);
-        $container->set('service_container', $container);
         $container->set('debug.stopwatch', $this->getMock('Symfony\Component\Stopwatch\Stopwatch'));
 
         $container->setParameter('foo', 'bar');

--- a/Tests/DependencyInjection/BazingaHateoasExtensionTest.php
+++ b/Tests/DependencyInjection/BazingaHateoasExtensionTest.php
@@ -33,7 +33,7 @@ class BazingaHateoasExtensionTest extends TestCase
         $container = $this->getContainerForConfig(array(array()));
         $container->compile();
 
-        $serializer = $container->get('serializer');
+        $serializer = $container->get('jms_serializer');
 
         $this->assertEquals(
             json_encode(array(

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">5.4",
         "symfony/framework-bundle": "~2.2 || ~3.0",
         "willdurand/hateoas": "^2.10.0",
-        "jms/serializer-bundle": "~1.0"
+        "jms/serializer-bundle": "~1.0 || ^2.0"
     },
     "require-dev": {
         "symfony/expression-language": "~2.4 || ~3.0",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">5.4",
-        "symfony/framework-bundle": "~2.2 || ~3.0",
+        "symfony/framework-bundle": "~2.3 || ~3.0",
         "willdurand/hateoas": "^2.10.0",
         "jms/serializer-bundle": "~1.0 || ^2.0"
     },


### PR DESCRIPTION
### JMS Serializer Bundle

Today I have released the JMS serializer bundle 2.0. The new version is almost 100% backward compatible with the 1.x, so no changes are required from the user point of view.
The changes are mainly about changing some defaults to optimize performance and DX, [here a full list](https://github.com/schmittjoh/JMSSerializerBundle/blob/master/UPGRADING.md)

### Build and symfony compatibility changes

On the way of integrating the new bundle, I have discovered some problems when the symfony 3.0 support was added (https://github.com/willdurand/BazingaHateoasBundle/commit/51c06604ebd11fe197a48f39ed9f6d31c898ad6c was a bit too optimistic and no builds on travis were updated)

### Details
Changes in this pr: 

 https://github.com/willdurand/BazingaHateoasBundle/pull/64/commits/c7628b85ba4a805b41fe55762026158875716895  allows jms serializer bundle 2.0 + changes the deprecated service alias 
https://github.com/willdurand/BazingaHateoasBundle/pull/64/commits/d21056e20cb8ba595e8557511472296c4e3df63b removes the deprecated "set service container call"
https://github.com/willdurand/BazingaHateoasBundle/pull/64/commits/993922fddce443889a4f211017c611837619706c runs builds into travis containers, adds tests for latest symfony releases and adds tests for low library versions
https://github.com/willdurand/BazingaHateoasBundle/pull/64/commits/4e458023a50ec5c0da5ee47a1129036272db6476 HHVM builds were green before... travis was misconfigured
https://github.com/willdurand/BazingaHateoasBundle/pull/64/commits/7f01b236acfb7bbeb8a3af437737ed48772e8118 symfony 2.2 was not supported and tests were failing when running it and min deps (dependency injection 2.8 was used)

hhvm builds are green too now
