### PR TITLE
Allow HHVM as a failure in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ php:
     - 5.6
     - 7.0
     - hhvm
+    
+matrix:
+  allow_failures:
+    - php: hhvm
 
 env:
     - SYMFONY_VERSION=2.3.*


### PR DESCRIPTION
Hi there, I was about to use your bundle but I noticed it was failing. So I looked in Travis and saw that it was HHVM causing the fauilure.

I added to the .travis.yml so it will still still test HHVM, but it will not cause a failed build if HHVM fails. :-)