### PR TITLE
symfony 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
         env: SYMFONY_VERSION=4.0.*
       - php: 7.0
         env: SYMFONY_VERSION=4.0.*
+      - php: hhvm
+        env: SYMFONY_VERSION=4.0.*
 
 env:
     - SYMFONY_VERSION=2.3.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,17 @@ php:
     - 5.5
     - 5.6
     - 7.0
+    - 7.1
     - hhvm
+
+matrix:
+    exclude:
+      - php: 5.5
+        env: SYMFONY_VERSION=4.0.*
+      - php: 5.6
+        env: SYMFONY_VERSION=4.0.*
+      - php: 7.0
+        env: SYMFONY_VERSION=4.0.*
 
 env:
     - SYMFONY_VERSION=2.3.*
@@ -26,6 +36,7 @@ env:
     - SYMFONY_VERSION=2.8.* DEPS=low
     - SYMFONY_VERSION=3.0.* DEPS=low
     - SYMFONY_VERSION=3.2.* DEPS=low
+    - SYMFONY_VERSION=4.0.*
 
 before_script:
     - if [ "$DEPS" = 'low' ] ; then COMPOSER_PARAMS="--prefer-lowest --prefer-stable" ;  fi

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Integration of Hateoas into Symfony2.",
     "keywords": [ "rest", "hateoas" ],
     "type": "symfony-bundle",
+    "minimum-stability": "dev",
     "license": "MIT",
     "authors": [
         {
@@ -11,15 +12,16 @@
     }
     ],
     "require": {
-        "php": ">5.4",
-        "symfony/framework-bundle": "~2.3 || ~3.0",
+        "php": ">5.4 |^7.0",
+        "symfony/framework-bundle": "~2.3 || ~3.0 || ~4.0",
         "willdurand/hateoas": "^2.10.0",
         "jms/serializer-bundle": "~1.0 || ^2.0"
     },
     "require-dev": {
-        "symfony/expression-language": "~2.4 || ~3.0",
+        "symfony/expression-language": "~2.4 || ~3.0 || ~4.0",
         "twig/twig": "~1.12",
-        "phpunit/phpunit": "~4.5"
+        "phpunit/phpunit": "~4.5 || ~5.0",
+        "symfony/stopwatch": "~2.4 || ~3.0 || ~4.0"
     },
     "autoload": {
         "psr-4": { "Bazinga\\Bundle\\HateoasBundle\\": "" }


### PR DESCRIPTION
Added symfony 4 and php 7.1 support in travis, excluded not supported version of php for symfony 4 related builds, adjusted test to work with symfony 4 and keep backward compatibility #SymfonyConfHackday2017