### PR TITLE
Example in the docs is broken

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -84,9 +84,9 @@ class SomeController extends Controller
     public function resourceAction(Request $request)
     {
         $post = $repository->find('BlogBundle:post');
-        $json = $this->container->get('serializer')->serialize($post, 'json');
+        $json = $this->container->get('jms_serializer')->serialize($post, 'json');
 
-        return new Response($json, 200, array('application/json'));
+        return new Response($json, 200, array('Content-Type' => 'application/json'));
     }
 }
 ````


### PR DESCRIPTION
The headers array is incomplete as it are supposed to be key-value pairs.
The `serializer` service is the SymfonySerializer not the JMSSerializer