### PR TITLE
Changed Symfony2 to Symfony

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013 William Durand <william.durand1@gmail.com>
+Copyright (c) 2017 William Durand <william.durand1@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ BazingaHateoasBundle
 [![Build Status](https://secure.travis-ci.org/willdurand/BazingaHateoasBundle.png)](http://travis-ci.org/willdurand/BazingaHateoasBundle)
 
 This bundle integrates [Hateoas](http://github.com/willdurand/Hateoas) with
-[Symfony2](http://symfony.com).
+[Symfony](http://symfony.com).
 
 
 Documentation

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -2,7 +2,7 @@ BazingaHateoasBundle
 ====================
 
 This bundle integrates [Hateoas](http://github.com/willdurand/Hateoas) into
-[Symfony2](http://symfony.com).
+[Symfony](http://symfony.com).
 
 Installation
 ------------


### PR DESCRIPTION
The project is not only compatible with Symfony2 but all upwards to the
current version, Symfony4. Using Symfony2 in place of Symfony may
discourage potential usage.