### PR TITLE
Adding jsm/serializer-bundle 3.0 as supported

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">5.4 |^7.0",
         "symfony/framework-bundle": "~2.3 || ~3.0 || ~4.0",
         "willdurand/hateoas": "^2.10.0",
-        "jms/serializer-bundle": "~1.0 || ^2.0"
+        "jms/serializer-bundle": "~1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "symfony/expression-language": "~2.4 || ~3.0 || ~4.0",


### PR DESCRIPTION
jms/serializer-bundle just bumped to version 3.0 with full backwards compatibility. Currently it is not possible to install HateoasBundle because of this conflict:
```
Problem 1
    - Installation request for willdurand/hateoas-bundle ^1.4 -> satisfiable by willdurand/hateoas-bundle[1.4.0].
    - willdurand/hateoas-bundle 1.4.0 requires jms/serializer-bundle ~1.0 || ^2.0 -> satisfiable by jms/serializer-bundle[1.0.0, 1.1.0, 1.2.0, 1.2.1, 1.3.0, 1.3.1, 1.4.0, 1.5.0, 2.0.0, 2.1.0, 2.2.0, 2.3.0, 2.3.1, 2.4.0, 2.4.1, 2.4.2, 2.x-dev] but these conflict with your requirements or minimum-stability.
```