### PR TITLE
Fix Deprecation Warnings.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,8 +22,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode    = $treeBuilder->root('bazinga_hateoas');
+        $treeBuilder = new TreeBuilder('bazinga_hateoas');
+        if (\method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('bazinga_hateoas');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
Fix deprecation for symfony/config 4.2+

(Greatly inspired by https://github.com/stof/StofDoctrineExtensionsBundle/pull/388/commits)