### PR TITLE
Remove array in is_granted argument

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -140,7 +140,7 @@ use Hateoas\Configuration\Annotation as Hateoas;
  *          parameters = { "id" = "expr(object.getId())" }
  *      ),
  *      exclusion = @Hateoas\Exclusion(
- *          excludeIf = "expr(not is_granted(['ROLE_ADMIN']))"
+ *          excludeIf = "expr(not is_granted('ROLE_ADMIN'))"
  *      )
  * )
  */


### PR DESCRIPTION
Hello !

I just change the array for a string in _is_granted_ method in documentation because pass an array doesn't work...