### PR TITLE
willdurand/Hateoas#325 support for php attributes

### DIFF
--- a/BazingaHateoasBundle.php
+++ b/BazingaHateoasBundle.php
@@ -10,6 +10,7 @@
 
 namespace Bazinga\Bundle\HateoasBundle;
 
+use Bazinga\Bundle\HateoasBundle\DependencyInjection\Compiler\AttributeDriverPass;
 use Bazinga\Bundle\HateoasBundle\DependencyInjection\Compiler\CacheWarmupPass;
 use Bazinga\Bundle\HateoasBundle\DependencyInjection\Compiler\ExtensionDriverPass;
 use Bazinga\Bundle\HateoasBundle\DependencyInjection\Compiler\RelationProviderPass;
@@ -28,6 +29,7 @@ class BazingaHateoasBundle extends Bundle
 
         $container->addCompilerPass(new UrlGeneratorPass());
         $container->addCompilerPass(new RelationProviderPass());
+        $container->addCompilerPass(new AttributeDriverPass());
         $container->addCompilerPass(new ExtensionDriverPass());
         $container->addCompilerPass(new CacheWarmupPass());
     }

--- a/DependencyInjection/Compiler/AttributeDriverPass.php
+++ b/DependencyInjection/Compiler/AttributeDriverPass.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the HateoasBundle package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Bazinga\Bundle\HateoasBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class AttributeDriverPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (PHP_VERSION_ID < 80100) {
+            $container->removeDefinition('hateoas.configuration.metadata.attribute_driver');
+        }
+    }
+}

--- a/Resources/config/configuration.xml
+++ b/Resources/config/configuration.xml
@@ -38,15 +38,30 @@
             <argument type="service" id="jms_serializer.type_parser" on-invalid="null" />
         </service>
 
+        <!-- The `Hateoas\Configuration\Metadata\Driver\AnnotationDriver` class and its corresponding `hateoas.configuration.metadata.annotation_driver` service are deprecated in favor of the `hateoas.configuration.metadata.attribute_driver` service -->
         <service id="hateoas.configuration.metadata.annotation_driver" class="Hateoas\Configuration\Metadata\Driver\AnnotationDriver" public="false">
-            <argument type="service" id="annotation_reader" />
+            <argument type="service" id="hateoas.configuration.metadata.annotation_reader" />
             <argument type="service" id="jms_serializer.expression_evaluator" />
             <argument type="service" id="hateoas.configuration.provider" />
             <argument type="service" id="jms_serializer.type_parser" on-invalid="null" />
         </service>
 
+        <service id="hateoas.configuration.metadata.attribute_driver" class="Hateoas\Configuration\Metadata\Driver\AttributeDriver" public="false">
+            <argument type="service" id="jms_serializer.expression_evaluator" />
+            <argument type="service" id="hateoas.configuration.provider" />
+            <argument type="service" id="jms_serializer.type_parser" on-invalid="null" />
+        </service>
+
+        <!-- The `hateoas.configuration.metadata.annotation_or_attribute_driver` is necessary to provide the extension feature to the `hateoas.configuration.metadata.attribute_driver` service -->
+        <service id="hateoas.configuration.metadata.annotation_or_attribute_driver" class="Metadata\Driver\DriverChain" public="false">
+            <argument type="collection">
+                <argument type="service" id="hateoas.configuration.metadata.attribute_driver" on-invalid="ignore" />
+                <argument type="service" id="hateoas.configuration.metadata.annotation_driver" />
+            </argument>
+        </service>
+
         <service id="hateoas.configuration.metadata.extension_driver" class="Hateoas\Configuration\Metadata\Driver\ExtensionDriver" public="false">
-            <argument type="service" id="hateoas.configuration.metadata.annotation_driver" />
+            <argument type="service" id="hateoas.configuration.metadata.annotation_or_attribute_driver" />
         </service>
 
         <service id="hateoas.configuration.metadata.chain_driver" class="Metadata\Driver\DriverChain" public="false">
@@ -68,6 +83,8 @@
         <service id="hateoas.configuration.metadata.cache.file_cache" class="Metadata\Cache\FileCache" public="false">
             <argument /><!-- Directory -->
         </service>
+
+        <service id="hateoas.configuration.metadata.annotation_reader" class="Doctrine\Common\Annotations\AnnotationReader" public="false" />
 
         <service id="hateoas.configuration.metadata.cache" alias="hateoas.configuration.metadata.cache.file_cache" public="false" />
 

--- a/Tests/DependencyInjection/BazingaHateoasExtensionTest.php
+++ b/Tests/DependencyInjection/BazingaHateoasExtensionTest.php
@@ -6,6 +6,7 @@ namespace Bazinga\Bundle\HateoasBundle\Tests\DependencyInjection;
 
 use Bazinga\Bundle\HateoasBundle\BazingaHateoasBundle;
 use Bazinga\Bundle\HateoasBundle\Tests\Fixtures\SimpleObject;
+use Doctrine\Common\Annotations\AnnotationReader;
 use JMS\SerializerBundle\JMSSerializerBundle;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -210,6 +211,7 @@ class BazingaHateoasExtensionTest extends TestCase
         $container->setDefinition('doctrine_phpcr', new Definition(Registry::class));
         $container->set('router', $router);
         $container->set('debug.stopwatch', $this->createMock(Stopwatch::class));
+        $container->set('annotation_reader', $this->createMock(AnnotationReader::class));
 
         $container->setParameter('foo', 'bar');
 

--- a/Tests/DependencyInjection/BazingaHateoasExtensionTest.php
+++ b/Tests/DependencyInjection/BazingaHateoasExtensionTest.php
@@ -6,7 +6,6 @@ namespace Bazinga\Bundle\HateoasBundle\Tests\DependencyInjection;
 
 use Bazinga\Bundle\HateoasBundle\BazingaHateoasBundle;
 use Bazinga\Bundle\HateoasBundle\Tests\Fixtures\SimpleObject;
-use Doctrine\Common\Annotations\AnnotationReader;
 use JMS\SerializerBundle\JMSSerializerBundle;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -143,6 +142,19 @@ class BazingaHateoasExtensionTest extends TestCase
         $container->compile();
     }
 
+    public function testSupportedAttributeDriver()
+    {
+        $container = $this->getContainerForConfig([[]]);
+        $container->compile();
+
+        // Hateoas attributes are supported as of php 8.1.
+        if (PHP_VERSION_ID < 80100) {
+            self::assertFalse($container->hasDefinition('hateoas.configuration.metadata.attribute_driver'));
+        } else {
+            self::assertTrue($container->hasDefinition('hateoas.configuration.metadata.attribute_driver'));
+        }
+    }
+
     private function clearTempDir()
     {
         // clear temporary directory
@@ -194,7 +206,6 @@ class BazingaHateoasExtensionTest extends TestCase
         $container->setParameter('kernel.cache_dir', $this->getTempDir());
         $container->setParameter('kernel.bundles', []);
         $container->setParameter('kernel.bundles_metadata', []);
-        $container->set('annotation_reader', new AnnotationReader());
         $container->setDefinition('doctrine', new Definition(Registry::class));
         $container->setDefinition('doctrine_phpcr', new Definition(Registry::class));
         $container->set('router', $router);
@@ -214,6 +225,9 @@ class BazingaHateoasExtensionTest extends TestCase
         }
 
         $container->getDefinition('hateoas.configuration.provider.chain')
+            ->setPublic(true);
+
+        $container->getDefinition('hateoas.configuration.metadata.attribute_driver')
             ->setPublic(true);
 
         return $container;

--- a/Tests/DependencyInjection/BazingaHateoasExtensionTest.php
+++ b/Tests/DependencyInjection/BazingaHateoasExtensionTest.php
@@ -206,12 +206,12 @@ class BazingaHateoasExtensionTest extends TestCase
         $container->setParameter('kernel.cache_dir', $this->getTempDir());
         $container->setParameter('kernel.bundles', []);
         $container->setParameter('kernel.bundles_metadata', []);
+        // The annotation_reader is used by JMSSerializerBundle versions lower than 5.4.0
+        $container->setAlias('annotation_reader', 'hateoas.configuration.metadata.annotation_reader');
         $container->setDefinition('doctrine', new Definition(Registry::class));
         $container->setDefinition('doctrine_phpcr', new Definition(Registry::class));
         $container->set('router', $router);
         $container->set('debug.stopwatch', $this->createMock(Stopwatch::class));
-        // The annotation_reader is used by JMSSerializerBundle versions lower than 5.4.0
-        $container->setAlias('annotation_reader', 'hateoas.configuration.metadata.annotation_reader');
 
         $container->setParameter('foo', 'bar');
 

--- a/Tests/DependencyInjection/BazingaHateoasExtensionTest.php
+++ b/Tests/DependencyInjection/BazingaHateoasExtensionTest.php
@@ -6,7 +6,6 @@ namespace Bazinga\Bundle\HateoasBundle\Tests\DependencyInjection;
 
 use Bazinga\Bundle\HateoasBundle\BazingaHateoasBundle;
 use Bazinga\Bundle\HateoasBundle\Tests\Fixtures\SimpleObject;
-use Doctrine\Common\Annotations\AnnotationReader;
 use JMS\SerializerBundle\JMSSerializerBundle;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -211,7 +210,8 @@ class BazingaHateoasExtensionTest extends TestCase
         $container->setDefinition('doctrine_phpcr', new Definition(Registry::class));
         $container->set('router', $router);
         $container->set('debug.stopwatch', $this->createMock(Stopwatch::class));
-        $container->set('annotation_reader', $this->createMock(AnnotationReader::class));
+        // The annotation_reader is used by JMSSerializerBundle versions lower than 5.4.0
+        $container->setAlias('annotation_reader', 'hateoas.configuration.metadata.annotation_reader');
 
         $container->setParameter('foo', 'bar');
 

--- a/Tests/Fixtures/SimpleObject.php
+++ b/Tests/Fixtures/SimpleObject.php
@@ -34,6 +34,10 @@ use JMS\Serializer\Annotation\Type;
  *    )
  * )
  */
+#[Hateoas\Relation(name: 'all', href: 'http://somewhere/simple-objects', attributes: ['foo' => 'expr(parameter("foo"))'])]
+#[Hateoas\Relation(name: 'all_2', href: 'expr(link(object, "all"))')]
+#[Hateoas\Relation(name: 'e1', embedded: new Hateoas\Embedded(content: 'expr(1)', type: 'string'))]
+#[Hateoas\Relation(name: 'e2', embedded: new Hateoas\Embedded(content: 'expr(2)', type: 'float', exclusion: new Hateoas\Exclusion(excludeIf: 'expr(false)')))]
 class SimpleObject
 {
     /**

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "jms/serializer-bundle": "^3.1 || ^4.2 || ^5.0",
         "symfony/expression-language": "~3.0 || ~4.0 || ~5.0 || ~6.0 || ~7.0",
         "symfony/framework-bundle": "~3.0 || ~4.0 || ~5.0 || ~6.0 || ~7.0",
-        "willdurand/hateoas": "^3.5"
+        "willdurand/hateoas": "^3.11@beta"
     },
     "require-dev": {
         "doctrine/annotations": "^1.13.2 || ^2.0",


### PR DESCRIPTION
Adds a new service `hateoas.configuration.metadata.attribute_driver` for the `AttributeDriver` class (https://github.com/willdurand/Hateoas/pull/326)

Moreover, `hateoas.configuration.metadata.attribute_driver` and `hateoas.configuration.metadata.annotation_driver` are combined in a new service `hateoas.configuration.metadata.annotation_or_attribute_driver` to give the extension feature to both services.

The `hateoas.configuration.metadata.attribute_driver` will be removed if the PHP version is prior 8.1.0, so the `hateoas.configuration.metadata.annotation_or_attribute_driver` will have only the annotation driver.

This PR will require a new release version of `willdurand/Hateoas`