### PR TITLE
Install doctrine/coding-standard v12

### DIFF
--- a/DependencyInjection/Compiler/AttributeDriverPass.php
+++ b/DependencyInjection/Compiler/AttributeDriverPass.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 class AttributeDriverPass implements CompilerPassInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function process(ContainerBuilder $container)
     {

--- a/DependencyInjection/Compiler/CacheWarmupPass.php
+++ b/DependencyInjection/Compiler/CacheWarmupPass.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 class CacheWarmupPass implements CompilerPassInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function process(ContainerBuilder $container)
     {

--- a/DependencyInjection/Compiler/ExtensionDriverPass.php
+++ b/DependencyInjection/Compiler/ExtensionDriverPass.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 class ExtensionDriverPass implements CompilerPassInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function process(ContainerBuilder $container)
     {

--- a/DependencyInjection/Compiler/RelationProviderPass.php
+++ b/DependencyInjection/Compiler/RelationProviderPass.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 class RelationProviderPass implements CompilerPassInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function process(ContainerBuilder $container)
     {

--- a/DependencyInjection/Compiler/UrlGeneratorPass.php
+++ b/DependencyInjection/Compiler/UrlGeneratorPass.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Reference;
 class UrlGeneratorPass implements CompilerPassInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function process(ContainerBuilder $container)
     {

--- a/Tests/DependencyInjection/BazingaHateoasExtensionTest.php
+++ b/Tests/DependencyInjection/BazingaHateoasExtensionTest.php
@@ -178,9 +178,7 @@ class BazingaHateoasExtensionTest extends TestCase
         return sys_get_temp_dir() . '/hateoas-bundle';
     }
 
-    /**
-     * @see https://github.com/schmittjoh/JMSSerializerBundle/blob/master/Tests/DependencyInjection/JMSSerializerExtensionTest.php
-     */
+    /** @see https://github.com/schmittjoh/JMSSerializerBundle/blob/master/Tests/DependencyInjection/JMSSerializerExtensionTest.php */
     private function getContainerForConfig(array $configs, ?KernelInterface $kernel = null)
     {
         if (null === $kernel) {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "doctrine/annotations": "^1.13.2 || ^2.0",
-        "doctrine/coding-standard": "^8.0",
+        "doctrine/coding-standard": "^12.0",
         "phpunit/phpunit": "^8.5.32 || ^9.5.10",
         "symfony/stopwatch": "~3.0 || ~4.0 || ~5.0 || ~6.0 || ~7.0",
         "twig/twig": "~1.12|~2.0|~3.0"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -34,6 +34,8 @@
 
         <exclude name="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment"/>
 
+        <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall.MissingTrailingComma"/>
+
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableParameterTypeHintSpecification"/>
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification"/>
@@ -84,9 +86,6 @@
         <exclude-pattern>Tests/*</exclude-pattern>
     </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint">
-        <exclude-pattern>Tests/*</exclude-pattern>
-    </rule>
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements">
         <exclude-pattern>Tests/*</exclude-pattern>
     </rule>
 


### PR DESCRIPTION
I just noticed that doctrine/coding-standard:8 blocks the installation of newer jms/serializer versions in the dev environment.