### PR TITLE
Enhancement: Adds void return type to `CompilerPass`

### DIFF
--- a/DependencyInjection/Compiler/AttributeDriverPass.php
+++ b/DependencyInjection/Compiler/AttributeDriverPass.php
@@ -19,7 +19,7 @@ class AttributeDriverPass implements CompilerPassInterface
     /**
      * {@inheritDoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!class_exists(AnnotationReader::class)) {
             $container->removeDefinition('hateoas.configuration.metadata.annotation_reader');

--- a/DependencyInjection/Compiler/AttributeDriverPass.php
+++ b/DependencyInjection/Compiler/AttributeDriverPass.php
@@ -16,9 +16,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class AttributeDriverPass implements CompilerPassInterface
 {
-    /**
-     * {@inheritDoc}
-     */
     public function process(ContainerBuilder $container): void
     {
         if (!class_exists(AnnotationReader::class)) {

--- a/DependencyInjection/Compiler/CacheWarmupPass.php
+++ b/DependencyInjection/Compiler/CacheWarmupPass.php
@@ -16,9 +16,6 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 class CacheWarmupPass implements CompilerPassInterface
 {
-    /**
-     * {@inheritDoc}
-     */
     public function process(ContainerBuilder $container): void
     {
         try {

--- a/DependencyInjection/Compiler/CacheWarmupPass.php
+++ b/DependencyInjection/Compiler/CacheWarmupPass.php
@@ -19,7 +19,7 @@ class CacheWarmupPass implements CompilerPassInterface
     /**
      * {@inheritDoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         try {
             $warmupService = clone $container->findDefinition('jms_serializer.cache.cache_warmer');

--- a/DependencyInjection/Compiler/ExtensionDriverPass.php
+++ b/DependencyInjection/Compiler/ExtensionDriverPass.php
@@ -20,7 +20,7 @@ class ExtensionDriverPass implements CompilerPassInterface
     /**
      * {@inheritDoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $extensionDriver = $container->getDefinition('hateoas.configuration.metadata.extension_driver');
 

--- a/DependencyInjection/Compiler/ExtensionDriverPass.php
+++ b/DependencyInjection/Compiler/ExtensionDriverPass.php
@@ -17,9 +17,6 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
 class ExtensionDriverPass implements CompilerPassInterface
 {
-    /**
-     * {@inheritDoc}
-     */
     public function process(ContainerBuilder $container): void
     {
         $extensionDriver = $container->getDefinition('hateoas.configuration.metadata.extension_driver');

--- a/DependencyInjection/Compiler/RelationProviderPass.php
+++ b/DependencyInjection/Compiler/RelationProviderPass.php
@@ -21,7 +21,7 @@ class RelationProviderPass implements CompilerPassInterface
     /**
      * {@inheritDoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $registryDefinition = $container->findDefinition('hateoas.configuration.provider');
 

--- a/DependencyInjection/Compiler/RelationProviderPass.php
+++ b/DependencyInjection/Compiler/RelationProviderPass.php
@@ -18,9 +18,6 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
 class RelationProviderPass implements CompilerPassInterface
 {
-    /**
-     * {@inheritDoc}
-     */
     public function process(ContainerBuilder $container): void
     {
         $registryDefinition = $container->findDefinition('hateoas.configuration.provider');

--- a/DependencyInjection/Compiler/UrlGeneratorPass.php
+++ b/DependencyInjection/Compiler/UrlGeneratorPass.php
@@ -20,7 +20,7 @@ class UrlGeneratorPass implements CompilerPassInterface
     /**
      * {@inheritDoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $registryDefinition = $container->getDefinition('hateoas.generator.registry');
 

--- a/DependencyInjection/Compiler/UrlGeneratorPass.php
+++ b/DependencyInjection/Compiler/UrlGeneratorPass.php
@@ -17,9 +17,6 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class UrlGeneratorPass implements CompilerPassInterface
 {
-    /**
-     * {@inheritDoc}
-     */
     public function process(ContainerBuilder $container): void
     {
         $registryDefinition = $container->getDefinition('hateoas.generator.registry');


### PR DESCRIPTION
In order to remove deprecations like, these CompilerPasses need to add a return type.

>  Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "Bazinga\Bundle\HateoasBundle\DependencyInjection\Compiler\UrlGeneratorPass" now to avoid errors or add an explicit @return annotation to suppress this message. 