### PR TITLE
Add void return type to the bundle

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   phpunit:
     name: "PHPUnit"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
 
     strategy:
       fail-fast: false

--- a/.github/workflows/coding-standards.yaml
+++ b/.github/workflows/coding-standards.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   coding-standards:
     name: "Coding Standards"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
 
     strategy:
       matrix:

--- a/BazingaHateoasBundle.php
+++ b/BazingaHateoasBundle.php
@@ -23,7 +23,7 @@ class BazingaHateoasBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 


### PR DESCRIPTION
Fixes the following deprecation warning:

> User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "Bazinga\Bundle\HateoasBundle\BazingaHateoasBundle" now to avoid errors or add an explicit @return annotation to suppress this message.

Furthermore, this PR bumps the Ubuntu version used in the CI because Ubuntu 20.04 is deprecated.